### PR TITLE
Use rename for atomic downloads on Unix 

### DIFF
--- a/bazel_external_data/core.py
+++ b/bazel_external_data/core.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 import subprocess
+import uuid
 
 from bazel_external_data import util, config_helpers, hashes
 
@@ -279,11 +280,15 @@ class Remote(object):
         # Helper functions.
 
         def download_file_direct(output_file):
+            # Assuming we're on Unix (where `os.rename` is atomic), use a
+            # tempfile to avoid race conditions.
+            tmp_file = output_file + "-" + str(uuid.uuid4())
             try:
-                self._download_file_direct(hash, project_relpath, output_file)
+                self._download_file_direct(hash, project_relpath, tmp_file)
             except util.DownloadError as e:
                 util.eprint("ERROR: For remote '{}'".format(self.name))
                 raise e
+            os.rename(tmp_file, output_file)
 
         def get_cached(check_sha):
             # Can use cache. Copy to output path.

--- a/test/external_data_pkg_test/workflows_test.sh
+++ b/test/external_data_pkg_test/workflows_test.sh
@@ -261,4 +261,8 @@ rm -rf ${upload_merge_dir}
 ../tools/external_data squash master extra merge --files ./subdir/extra.bin
 [[ $(find ${upload_merge_dir} -type f | wc -l) -eq 1 ]]
 
+# Briefly test race conditions by building both locally and externally.
+bazel clean
+bazel build //data @external_data_pkg_test//data
+
 echo "[ Done ]"


### PR DESCRIPTION
Also fixes Girder testing bits, and updates README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/bazel-external-data/4)
<!-- Reviewable:end -->
