### PR TITLE
extract_archive: Nix genrule for performance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# These lines tell reviewable.io how to highlight source code.
+WORKSPACE diff=python
+**/*.bzl diff=python
+**/BUILD.bazel diff=python
+**/*.BUILD.bazel diff=python


### PR DESCRIPTION
Pending additional testing, it seems to me that avoiding the `genrule()` formulation during `extract_archive` makes it much nicer for the caching system.

We still need to use `genrule()` with `local = 1` for the actual archive downloads and archive caching, but the unpack step can be hermetic, be remote-disk-cached, not depend on `$PATH`, etc.

I am going to test this more with Anzu before seeking review here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/bazel-external-data/19)
<!-- Reviewable:end -->
