### PR TITLE
Fix several TOCTOU bugs in uses of os.makedirs

### DIFF
--- a/bazel_external_data/backends/mock.py
+++ b/bazel_external_data/backends/mock.py
@@ -46,8 +46,7 @@ class MockBackend(Backend):
         dest = os.path.join(self._upload_dir, hash.get_value())
         assert not os.path.exists(dest)
         dest_dir = os.path.dirname(dest)
-        if not os.path.isdir(dest_dir):
-            os.makedirs(dest_dir)
+        os.makedirs(dest_dir, exist_ok=True)
         # Copy the file.
         shutil.copy(filepath, dest)
         # Store the SHA.

--- a/bazel_external_data/backends/test/docker_girder/setup_server.py
+++ b/bazel_external_data/backends/test/docker_girder/setup_server.py
@@ -70,8 +70,7 @@ if my_plugin not in enabled:
 # To be run by `setup_client.sh`.
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(cur_dir)
-if not os.path.exists("build"):
-    os.makedirs("build")
+os.makedirs("build", exist_ok=True)
 output_file = "build/info.yml"
 
 with open(output_file, 'w') as f:

--- a/bazel_external_data/backends/test/girder_test.py
+++ b/bazel_external_data/backends/test/girder_test.py
@@ -67,10 +67,8 @@ backend = GirderHashsumBackend(config, project_root, user)
 relpath = "test.txt"
 path = os.path.join(project_root, relpath)
 
-if not os.path.exists(project_root):
-    os.makedirs(project_root)
-if not os.path.exists(output):
-    os.makedirs(output)
+os.makedirs(project_root, exist_ok=True)
+os.makedirs(output, exist_ok=True)
 
 for _i in range(args.num_loops):
     print("Outer: {}".format(_i))

--- a/bazel_external_data/core.py
+++ b/bazel_external_data/core.py
@@ -388,6 +388,5 @@ def _get_hash_cache_path(cache_dir, hash, create_dir=True):
     hash_value = hash.get_value()
     out_dir = os.path.join(
         cache_dir, hash_algo, hash_value[0:2], hash_value[2:4])
-    if create_dir and not os.path.isdir(out_dir):
-        os.makedirs(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
     return os.path.join(out_dir, hash_value)

--- a/bazel_external_data/squash.py
+++ b/bazel_external_data/squash.py
@@ -69,8 +69,7 @@ def run(args, project):
         # upload to `merge`.
         file_stage_abspath = os.path.join(stage_dir, info.project_relpath)
         file_stage_dir = os.path.dirname(file_stage_abspath)
-        if not os.path.exists(file_stage_dir):
-            os.makedirs(file_stage_dir)
+        os.makedirs(file_stage_dir, exist_ok=True)
         head.download_file(
             info.hash, info.project_relpath, file_stage_abspath, symlink=True)
         # Upload file to `merge`.


### PR DESCRIPTION
 * Checking the filsystem and then acting on it is a TOCTOU violation.
 * os.makedirs() has an exist_ok flag to avoid this bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/bazel-external-data/29)
<!-- Reviewable:end -->
