### PR TITLE
Fix --incompatible_disallow_empty_glob=true for Bazel 8

### DIFF
--- a/expose_all_files.bzl
+++ b/expose_all_files.bzl
@@ -71,12 +71,12 @@ def expose_all_files(
     else:
         package_prefix = "//"  # Root case.
     for name, patterns in _patterns_map.items():
-        srcs = native.glob(patterns)
+        srcs = native.glob(patterns, allow_empty = True)
         for sub_dir in sub_dirs:
             srcs += native.glob([
                 sub_dir + "/**/" + pattern
                 for pattern in patterns
-            ])
+            ], allow_empty = True)
         native.filegroup(
             name = name,
             srcs = srcs,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/bazel-external-data/33)
<!-- Reviewable:end -->
